### PR TITLE
Add wooden dagger to training weapons

### DIFF
--- a/content/fighting.lua
+++ b/content/fighting.lua
@@ -375,8 +375,7 @@ end
 function M.IsTrainingWeapon( ItemID )
     local woodenSword = 445;
     local woodenDagger = 1045;
-    local woodenClub = 2664;
-    return ( ItemID == woodenSword or ItemID == woodenDagger or ItemID == woodenClub);
+    return ( ItemID == woodenSword or ItemID == woodenDagger );
 end;
 
 --- Get a area that is hit during a attack. Depending on the race the areas that

--- a/content/fighting.lua
+++ b/content/fighting.lua
@@ -373,7 +373,10 @@ end
     @return boolean training weapon or not
 ]]
 function M.IsTrainingWeapon( ItemID )
-    return ( ItemID == 445 );
+    local woodenSword = 445;
+    local woodenDagger = 1045;
+    local woodenClub = 2664;
+    return ( ItemID == woodenSword or ItemID == woodenDagger or ItemID == woodenClub);
 end;
 
 --- Get a area that is hit during a attack. Depending on the race the areas that


### PR DESCRIPTION
Please note, the wooden club appears to be the only current level 0 weapon for blunt. This currently makes that into a training weapon, which does much less damage than a normal level 0 weapon.