### PR TITLE
Parchment

### DIFF
--- a/item/id_2745_parchment.lua
+++ b/item/id_2745_parchment.lua
@@ -70,13 +70,16 @@ function M.UseItem(User, SourceItem,ltstate,checkVar)
     end
 
     if not common.IsNilOrEmpty(SourceItem:getData("writtenText")) then
-        User:inform("Du liest:","You read:")
         local writtenText = SourceItem:getData("writtenText")
-        writtenText = string.gsub (writtenText,"\\n","\n")
         if not common.IsNilOrEmpty(SourceItem:getData("signatureText")) then
             writtenText = writtenText .. "\n~" .. SourceItem:getData("signatureText") .. "~"
         end
-        User:inform(writtenText)
+        local dialog = MessageDialog(
+            "Parchment",
+            writtenText,
+            --[[callback=]]function(d) end
+            )
+        User:requestMessageDialog(dialog)
     end
 end
 

--- a/item/id_2745_parchment.lua
+++ b/item/id_2745_parchment.lua
@@ -75,7 +75,7 @@ function M.UseItem(User, SourceItem,ltstate,checkVar)
             writtenText = writtenText .. "\n~" .. SourceItem:getData("signatureText") .. "~"
         end
         local dialog = MessageDialog(
-            "Parchment",
+            common.GetNLS(User, "Pergament", "Parchment"),
             writtenText,
             --[[callback=]]function(d) end
             )

--- a/item/id_463_quill.lua
+++ b/item/id_463_quill.lua
@@ -163,7 +163,7 @@ local function WriteParchment(User,SourceItem)
     end
 
     local title = getText(User, "Pergament beschreiben", "Write Parchment")
-    local infoText = getText(User, "FIXGERMAN Füge hier den Text ein, den du auf das Pergament schreiben willst.", "Enter the line you want to add to the parchment.")
+    local infoText = getText(User, "Füge hier die Zeile ein, die du dem Pergament hinzufügen möchtest.", "Enter the line you want to add to the parchment.")
     local parchment = CheckIfParchmentInHand(User,SourceItem)
     local oldWrittenText = parchment:getData("writtenText")
 
@@ -172,13 +172,14 @@ local function WriteParchment(User,SourceItem)
         return
     end
     local _, lineCount = string.gsub(oldWrittenText, "\n", "\n")
-    if lineCount > parchmentMaxLineNumber then
-        User:inform("FIXGERMAN Du findest nicht genügend freien Platz auf dem Pergament.","The parchment is too small to add more lines.",Character.highPriority)
+    lineCount = lineCount + 1  -- last line has no \n
+    if lineCount >= parchmentMaxLineNumber then
+        User:inform("Du findest nicht genügend freien Platz auf dem Pergament.","The parchment is too small to add more lines.",Character.highPriority)
         return
     end
 
     if not common.IsNilOrEmpty(oldWrittenText) then
-        infoText = infoText .. getText(User, "\nFIXGERMAN\n\n", "\nCurrent text is:\n\n")
+        infoText = infoText .. getText(User, "\nAktuell steht hier:\n\n", "\nCurrent text is:\n\n")
         infoText = infoText .. oldWrittenText
     end
     local dialog = InputDialog(title, infoText, false, parchmentMaxLineLength, callback)


### PR DESCRIPTION
Improve parchment write/read interface
- reading is shown as message dialog (instead of notify)
- when adding a new line you see what has already been written
- auto-open dialog to add next line (saves several clicks and makes writing multi-line parchments bearable)
- changed text limit: up to 10 lines up to 24 chars each, instead of 100 chars in total.