### PR TITLE
Expand sacrifice lists

### DIFF
--- a/content/_gods/cherga.lua
+++ b/content/_gods/cherga.lua
@@ -42,6 +42,7 @@ function M.Cherga:_init(ordinal, youngerOrdinal)
     self.sacrificeItems = {  -- array of tables defining groups of items for sacrificing
         {
             id_set = common.setFromList({ -- set of item IDs
+                763, --marsh flower
                 -- light sources
                 -- all light sources have price==0 when lit, so we currently use only unlit ones and their fuel
                 391, -- torch

--- a/content/_gods/cherga.lua
+++ b/content/_gods/cherga.lua
@@ -40,7 +40,7 @@ function M.Cherga:_init(ordinal, youngerOrdinal)
         {id = 182, number = 1}, -- black shirt
     }
     self.sacrificeItems = {  -- array of tables defining groups of items for sacrificing
-        {  -- TODO more items
+        {
             id_set = common.setFromList({ -- set of item IDs
                 -- light sources
                 -- all light sources have price==0 when lit, so we currently use only unlit ones and their fuel
@@ -53,6 +53,41 @@ function M.Cherga:_init(ordinal, youngerOrdinal)
                 -- burial
                 24, -- shovel
                 733, -- stone block (symbolizing gravestone)
+                314, --Potash, symbolizing cremated remains
+                -- Reaper imagery?
+                271, -- scythe ?
+                2723, -- executioner's axe ?
+                39, -- skull staff
+                138, --Night Angels Blossom
+                -- ## From craft\final\tailoring.lua ##
+                -- category: Cloth gloves
+                1447, -- grey cloth gloves
+                1449, -- black cloth gloves
+                -- category: Dresses
+                802, -- grey dress
+                805, -- black dress
+                838, -- black white dress
+                850, -- grey heraldic dress
+                -- category: Robes
+                196, -- grey coat
+                2418, -- grey priest robe
+                194, -- black robe
+                2378, -- black cult robe
+                2384, -- black coat
+                2420, -- black priest robe
+                -- category: Shirts
+                182, -- black shirt
+                -- category: Skirts
+                841, -- grey white skirt
+                844, -- black white skirt
+                -- category: Trousers
+                823, -- grey trousers
+                34, -- short black trousers
+                826, -- black trousers
+                -- category: Tunics
+                816, -- grey tunic
+                819, -- black tunic
+
             }),
             minimal_quality = 0, -- int in 1..9 - if present, item quality has to be greater or equal
             minimal_durability = 0, -- int in 0..99 - if present, item durability has to be greater or equal

--- a/content/_gods/elara.lua
+++ b/content/_gods/elara.lua
@@ -42,6 +42,7 @@ function M.Elara:_init(ordinal, youngerOrdinal)
     self.sacrificeItems = {  -- array of tables defining groups of items for sacrificing
         {
             id_set = common.setFromList({ -- set of item IDs
+                144, --virgin's weed
                 -- light sources
                 391, -- torch
                 43, -- candle

--- a/content/_gods/irmorom.lua
+++ b/content/_gods/irmorom.lua
@@ -40,6 +40,7 @@ function M.Irmorom:_init(ordinal, youngerOrdinal)
         {id = 101, number = 1}, -- chain mail
     }
     local ids = common.setFromList({ -- set of item IDs
+        762, --gold crack herb
         -- ## From craft\final\armourer.lua ##
         -- category: Chain boots
         1507, -- simple jackboots

--- a/content/_gods/malachin.lua
+++ b/content/_gods/malachin.lua
@@ -122,6 +122,9 @@ function M.Malachin:_init(ordinal, youngerOrdinal)
                 3035, -- drow sword
                 -- ## From craft\final\carving.lua ##
                 -- category: Arrows and bolts
+                64, -- arrow
+                237, -- crossbow bolt
+                322, -- wind arrows
                 -- category: Blunt weapons
                 2664, -- club
                 230, -- mace

--- a/content/_gods/malachin.lua
+++ b/content/_gods/malachin.lua
@@ -50,6 +50,7 @@ function M.Malachin:_init(ordinal, youngerOrdinal)
         },
         {
             id_set = common.setFromList({ -- set of item IDs
+                768, --Wolverine Fern
                 -- ## From craft\final\blacksmithing.lua ##
                 -- category: Daggers
                 27, -- simple dagger

--- a/content/_gods/moshran.lua
+++ b/content/_gods/moshran.lua
@@ -41,19 +41,291 @@ function M.Moshran:_init(ordinal, youngerOrdinal)
         {id = 2776, number = 1}, -- machete
     }
     self.sacrificeItems = {  -- array of tables defining groups of items for sacrificing
-        {  -- TODO more items or something special
+        {
+            -- triple value for orc and drow equipment
             id_set = common.setFromList({ -- set of item IDs
+                2642, -- orc axe
+                16, -- orc helmet
+                2777, -- drow blade
+                3035, -- drow sword
+                2303, -- drow helmet
+                2402, -- drow armour
+                2739, -- drow bow
+            }),
+            minimal_quality = 0, -- int in 1..9 - if present, item quality has to be greater or equal
+            minimal_durability = 0, -- int in 0..99 - if present, item durability has to be greater or equal
+            value_multiplier = 3, -- float -- the monetary value gets multiplied by this
+        },
+        {
+            -- Big bonus for dragon eggs
+            id_set = common.setFromList({ -- set of item IDs
+                738 --Dragon egg
+            }),
+            minimal_quality = 0, -- int in 1..9 - if present, item quality has to be greater or equal
+            minimal_durability = 0, -- int in 0..99 - if present, item durability has to be greater or equal
+            value_multiplier = 5, -- float -- the monetary value gets multiplied by this
+        },
+        {id_set = common.setFromList({ -- set of item IDs
+            -- Miscellaneous
                 466, -- Handcuffs?
                 2760, -- Rope?
                 63, -- Entrails
-                -- raw meat?
+                374, -- trap set
+                283, -- Cut Obsidian
+                449, -- Obsidian powder
+                136, --Anger berry
+                141, --Black thistle
+                391, -- torch
+                333, --horn (warhorn)
+                2681, --Bucket of red dye, symbolizing blood
+                3078, --Poison coins
+            -- Poisonous substances from food.lua
+                158, --bulbsponge
+                159, --toadstool
+                162, --birth mushroom
+            -- raw meat?
                 307, -- Pork
                 1151, -- Chicken meat
                 553, -- Rabbit meat
                 2934, -- Lamb meat
                 552, -- Deer meat
                 2940, -- Raw steak
-            }),
+                -- ## From craft\final\blacksmithing.lua ##
+                -- category: Daggers
+                27, -- simple dagger
+                189, -- dagger
+                1524, -- sharp dagger
+                398, -- coppered dagger
+                190, -- ornate dagger
+                2740, -- red dagger
+                389, -- silvered dagger
+                297, -- gilded dagger
+                2672, -- ritual dagger
+                2675, -- rapier
+                --91, -- Malachín dagger
+                444, -- merinium-plated dagger
+                2671, -- magical dagger
+                2742, -- red fire dagger
+                -- category: One handed axes
+                2629, -- light battle axe
+                2711, -- halfling axe
+                2946, -- battle axe
+                192, -- coppered battle axe
+                229, -- silvered battle axe
+                124, -- gilded battle axe
+                --2642, -- orc axe
+                2660, -- dwarven axe
+                296, -- merinium-plated battle axe
+                2662, -- magical dwarven axe
+                -- category: One handed swords
+                2776, -- machete
+                25, -- sabre
+                78, -- short sword
+                1, -- serinjah sword
+                2757, -- scimitar
+                2701, -- longsword
+                85, -- coppered longsword
+                98, -- silvered longsword
+                2658, -- broadsword
+                2778, -- elven sword
+                84, -- gilded longsword
+                2775, -- elven rainbowsword
+                2788, -- snake sword
+                123, -- merinium-plated longsword
+                206, -- fire longsword
+                2693, -- magical serinjah-sword
+                2704, -- magical longsword
+                2654, -- magical broadsword
+                2656, -- fire broadsword
+                -- category: Throwing weapons
+                2645, -- throwing axe
+                294, -- throwing star
+            -- category: Two handed axes
+                2723, -- executioner's axe
+                88, -- longaxe
+                383, -- waraxe
+                188, -- large waraxe
+                1527, -- cleaver axe
+                205, -- double axe
+                2627, -- fire waraxe
+                2640, -- large fire-waraxe
+                2626, -- magical waraxe
+            -- category: Two handed swords
+                1525, -- flamberge
+                204, -- greatsword
+                1526, -- claymore
+                2731, -- two-handed sword
+            -- ## From craft\final\carving.lua ##
+            -- category: Arrows and bolts
+                64, -- arrow
+                237, -- crossbow bolt
+                322, -- wind arrows
+            -- category: Blunt weapons
+                2664, -- club
+                230, -- mace
+                1521, -- nail club
+                231, -- battle flail
+                1522, -- maul
+                2737, -- war flail
+                1044, -- battle hammer
+                226, -- warhammer
+                1523, -- heavy hammer
+                1041, -- spiked mace
+                1043, -- dwarven hammer
+                1052, -- dwarven stormhammer
+            -- category: Spears
+                1046, -- simple spear
+                1038, -- snake spear
+                1047, -- glaive
+                1049, -- viper spear
+                1040, -- ranseur
+                1048, -- voulge
+                77, -- halberd
+                1042, -- partisan
+                -- 1053, -- divine voulge
+                1039, -- twinblade ranseur
+                1050, -- shadow ranseur
+                -- 1051, -- partisan of light
+            -- category: Staffs
+                -- 1090, -- walking stick
+                39, -- skull staff
+                -- 40, -- cleric's staff
+                -- 1528, -- novice's staff
+                -- 57, -- simple mage's staff
+                -- 1529, -- adepts's staff
+                -- 76, -- mage's staff
+                -- 209, -- elven mage's staff
+                207, -- battle staff
+                -- 208, -- ornate mage's staff
+                1530, -- master's staff
+            -- category: Throwing weapons
+                293, -- javelin
+            -- ## From craft\final\finesmithing.lua ##
+            -- category: Crowns
+                3557, -- kings's crown
+                225, -- crown
+            -- category: Amulets
+                3536, -- copper obsidian amulet
+                3538, -- silver obsidian amulet
+                82, -- golden obsidian amulet
+            -- category: Rings
+                3537, -- copper obsidian ring
+                3561, -- silver obsidian ring
+                278, -- golden obsidian ring
+            -- ## From craft\final\planing.lua ##
+            -- category: Bows
+                65, -- short bow
+                1531, -- rider's bow
+                2646, -- serinjah-rider's bow
+                2714, -- hunting bow
+                2708, -- long bow
+                70, -- crossbow
+                2685, -- elven shortbow
+                2780, -- ebony wood bow
+                2718, -- elven composite longbow
+                2727, -- fire hunter's bow
+            -- category: Shields
+                2445, -- small wooden shield
+                17, -- wooden shield
+                18, -- light shield
+                917, -- red warden's shield
+                19, -- metal shield
+                20, -- knight shield
+                186, -- round metal shield
+                2388, -- red steel shield
+                2448, -- legionnaire's tower shield
+                95, -- heraldic shield
+                96, -- steel tower shield
+                916, -- ornate tower shield
+                2284, -- shield of the sky
+                2447, -- mosaic shield
+                2439, -- cloud shield
+            -- ## From craft\final\tailoring.lua ##
+            -- category: Boots
+                1500, -- simple leather shoes
+                369, -- leather shoes
+                1501, -- robust leather shoes
+                1502, -- simple leather boots
+                53, -- leather boots
+                1503, -- robust leather boots
+                1504, -- simple fur boots
+                697, -- fur boots
+                1505, -- robust fur boots
+                698, -- serinjah leather boots
+                1506, -- leather boots of the winds
+            -- category: Cloth gloves
+                1449, -- black cloth gloves
+                1450, -- red cloth gloves
+            -- category: Doublets
+                812, -- black doublet
+                811, -- red doublet
+            -- category: Greaves
+                1478, -- simple short leather leggings
+                367, -- short leather leggings
+                1479, -- reinforced short leather leggings
+                1480, -- simple leather leggings
+                366, -- leather leggings
+                1481, -- reinforced leather leggings
+                1482, -- simple short fur trousers
+                2114, -- short fur trousers
+                1483, -- reinforced short fur trousers
+                2113, -- fur trousers
+                1484, -- fur trousers of dawn
+            -- category: Hats
+                3708, -- witch hat
+            -- category: Helmets
+                1416, -- simple horned helmet
+                7, -- horned helmet
+                1417, -- coppered horned helmet
+                1418, -- silvered horned helmet
+                1419, -- gilded horned helmet
+                1420, -- bull horned helmet
+                1421, -- Norodaj horned helmet
+                1422, -- demonic horned helmet
+                1423, -- merinium plated horned helmet
+                1424, -- dragon horned helmet
+            -- category: Leather gloves
+                1453, -- simple leather gloves
+                384, -- thief's gloves
+                48, -- leather gloves
+                1454, -- reinforced leather gloves
+                526, -- studded leather gloves
+                1455, -- copper studded leather gloves
+                1456, -- silver studded leather gloves
+                1457, -- gold studded leather gloves
+                527, -- serinjah leather gloves
+                1458, -- reinforced serinjah leather gloves
+                1459, -- ranger's gloves
+            -- category: Robes
+                194, -- black robe
+                2378, -- black cult robe
+                2384, -- black coat
+                2420, -- black priest robe
+            -- category: Shirts
+                182, -- black shirt
+                180, -- red shirt
+            -- category: Torso armour
+                1433, -- padded armour
+                363, -- leather scale armour
+                1434, -- simple rogue armour
+                2407, -- light rogue armour
+                365, -- half leather armour
+                1435, -- simple hunting armour
+                1436, -- hunting armour
+                2399, -- light elven armour
+                2357, -- assassin's armour
+                364, -- reinforced hunting armour
+                362, -- full leather armour
+                1437, -- assassin's armour of darkness
+            -- category: Trousers
+                34, -- short black trousers
+                826, -- black trousers
+                459, -- short red trousers
+                825, -- red trousers
+            -- category: Tunics
+                819, -- black tunic
+                818, -- red tunic
+        }),
             minimal_quality = 0, -- int in 1..9 - if present, item quality has to be greater or equal
             minimal_durability = 0, -- int in 0..99 - if present, item durability has to be greater or equal
             value_multiplier = 1, -- float -- the monetary value gets multiplied by this

--- a/content/_gods/oldra.lua
+++ b/content/_gods/oldra.lua
@@ -128,6 +128,24 @@ function M.Oldra:_init(ordinal, youngerOrdinal)
                 149, --fir tree sprout
                 759, --nuts
 
+                --Rare herbs from gaia.lua
+                138, -- night angels blossom
+                146, -- desert sky capsule
+                152, -- life root
+                754, -- oneleaved fourberry
+                755, -- fire root
+                756, -- pious berry
+                757, -- tybalt star
+                758, -- heart blood
+                760, -- ice leaf
+                761, -- rain weed
+                762, -- gold crack herb
+                764, -- dark moos
+                765, -- day tream
+                766, -- con blossom
+                768, -- wolverine fern
+                769, -- desert berry
+
                 --Other foodstuffs
                 2502, --Bottle of milk
                 800, --bottle with sheep milk

--- a/content/_gods/oldra.lua
+++ b/content/_gods/oldra.lua
@@ -97,6 +97,54 @@ function M.Oldra:_init(ordinal, youngerOrdinal)
                 778, -- sugarcane
                 -- 772, -- tabacco - Not for Oldra
                 3567, -- Potatoes
+
+                -- ## From craft\gathering\herbgathering
+                144, --virgins weed
+                137, --flamegoblet blossom
+                135, --yellow weed
+                148, --firnis blossom
+                763, --mash flower
+                767, --water blossom
+                140, --donf blade
+                156, --steppe fern
+                153, --foot leaf
+                752, --mandrake
+                142, --sand berry
+                143, --red elder
+                136, --anger berry
+                134, --fourleafed oneberry
+                155, --sibanac
+                151, --strawberry
+                141, --black thistle
+                145, --heath flower
+                133, --sun herb
+                753, --blue bird's berry
+                159, --toadstool
+                160, --red head
+                161, --herder's mushroom
+                162, --birth mushroom
+                158, --bulbsponge mushroom
+                163, --champignon
+                149, --fir tree sprout
+                759, --nuts
+
+                --Other foodstuffs
+                2502, --Bottle of milk
+                800, --bottle with sheep milk
+
+                --Juices and teas (Alcohols go to Adron)
+                783, -- bottle of blackberry juice
+                784, -- bottle of tangerine juice
+                785, -- bottle of banana juice
+                786, -- bottle of cabbage juice
+                787, -- bottle of virgings weed tea
+                788, -- bottle of carrot juice
+                789, -- bottle of strawberry juice
+                791, -- bottle of grape juice
+                3611, -- bottle of orange juice
+                3720, -- bottle of fir needle tea
+                3721, -- bottle of green tea
+                3722, -- bottle of druids tea
             }),
             minimal_quality = 0, -- int in 1..9 - if present, item quality has to be greater or equal
             minimal_durability = 0, -- int in 0..99 - if present, item durability has to be greater or equal

--- a/content/_gods/ronagan.lua
+++ b/content/_gods/ronagan.lua
@@ -42,6 +42,7 @@ function M.Ronagan:_init(ordinal, youngerOrdinal)
     self.sacrificeItems = {  -- array of tables defining groups of items for sacrificing
         {
             id_set = common.setFromList({ -- set of item IDs
+                766, --con blossom
                 -- ## From craft\final\blacksmithing.lua ##
                 -- category: Daggers
                 27, -- simple dagger

--- a/content/_gods/sirani.lua
+++ b/content/_gods/sirani.lua
@@ -45,6 +45,8 @@ function M.Sirani:_init(ordinal, youngerOrdinal)
                 -- ## manual
                 -- category: flowers
                 148, -- firnis blossom
+                144, --virgins weed
+                767, --water blossom
                 -- ## From craft\final\finesmithing.lua ##
                 -- category: Amulets
                 222, -- iron amulet

--- a/content/_gods/sirani.lua
+++ b/content/_gods/sirani.lua
@@ -45,8 +45,6 @@ function M.Sirani:_init(ordinal, youngerOrdinal)
                 -- ## manual
                 -- category: flowers
                 148, -- firnis blossom
-                144, --virgins weed
-                767, --water blossom
                 -- ## From craft\final\finesmithing.lua ##
                 -- category: Amulets
                 222, -- iron amulet

--- a/content/_gods/zhambra.lua
+++ b/content/_gods/zhambra.lua
@@ -42,6 +42,7 @@ function M.Zhambra:_init(ordinal, youngerOrdinal)
     self.sacrificeItems = {  -- array of tables defining groups of items for sacrificing
         {
             id_set = common.setFromList({ -- array of item IDs
+                769, --desert berry
                 -- ## From craft\final\armourer.lua ##
                 -- category: Chain boots
                 1507, -- simple jackboots

--- a/item/altars.lua
+++ b/item/altars.lua
@@ -20,17 +20,17 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
 -- REFERENCE_IN_LUA - DATA - MEANING
 --Elder Gods
 -- gods.GOD_USHARA   -  1 - Ushara - Goddess of earth
--- gods.GOD_BRAGON   -  2 - Brï¿½gon - God of fire
+-- gods.GOD_BRAGON   -  2 - Brágon - God of fire
 -- gods.GOD_ELDAN    -  3 - Eldan - God of spirit
 -- gods.GOD_TANORA   -  4 - Tanora/Zelphia - Goddess of water
 -- gods.GOD_FINDARI  -  5 - Findari - Goddess of air
 --Younger Gods
--- gods.GOD_NARGUN   -  6 - Nargï¿½n - God of chaos
+-- gods.GOD_NARGUN   -  6 - Nargùn - God of chaos
 -- gods.GOD_ELARA    -  7 - Elara - Goddess of wisdom and knowledge
 -- gods.GOD_ADRON    -  8 - Adron - God of festivities and wine
 -- gods.GOD_OLDRA    -  9 - Oldra - Goddess of life and fertility
 -- gods.GOD_CHERGA   - 10 - Cherga - Goddess of spirits and the underworld
--- gods.GOD_MALACHIN - 11 - Malachï¿½n - God of battle and hunting
+-- gods.GOD_MALACHIN - 11 - Malachín - God of battle and hunting
 -- gods.GOD_IRMOROM  - 12 - Irmorom - God of trade and craftsmanship
 -- gods.GOD_SIRANI   - 13 - Sirani - Goddess of love and pleasure
 -- gods.GOD_ZHAMBRA  - 14 - Zhambra - God of friendship and loyalty
@@ -83,16 +83,16 @@ local M = {}
 ----These are the items I need to become a devotee
 --local devoteItems = {};
 --devoteItems[1] = { 733, 316, 2588 }; --Ushara: Stone block, Quartz sand, Brick
---devoteItems[2] = { 314, 236, 43 }; --Brï¿½gon: potash, Gold ignot, Candle
+--devoteItems[2] = { 314, 236, 43 }; --Brágon: potash, Gold ignot, Candle
 --devoteItems[3] = { 256, 2745, 155 }; --Eldan: Raw diamonds, Parchment, Sibanac leaf
 --devoteItems[4] = { 52, 253, 72 }; --Tanora: Bucket of water, Raw sapphire, Fishing rod
 --devoteItems[5] = { 64, 463, 65 }; --Findari: Arrow, Quill, Short Bow
---devoteItems[6] = { 80, 356, 733 }; --Nargï¿½n: Banana, Slouch hat, Stone block
+--devoteItems[6] = { 80, 356, 733 }; --Nargùn: Banana, Slouch hat, Stone block
 --devoteItems[7] = { 2745, 43, 463 }; --Elara: Parchment, Candle, Quill
 --devoteItems[8] = { 223, 2500, 388 }; --Adron: Iron Goblet, Bottle of Wine, Grapes
 --devoteItems[9] = { 258, 534, 259 }; --Oldra: Flail, Onion seeds, Grain
 --devoteItems[10] = { 24, 43, 182 }; --Cherga: Shovel, Candle, Black shirt
---devoteItems[11] = { 19, 65, 2586 }; --Malachï¿½n: Metal shield, Short bow, Fur
+--devoteItems[11] = { 19, 65, 2586 }; --Malachín: Metal shield, Short bow, Fur
 --devoteItems[12] = { 3077, 23, 2140 }; --Irmorom: Silver coin, Hammer, Tongs
 --devoteItems[13] = { 235, 148, 174 }; --Sirani: Gold ring, Firnis blossom, Red cloth
 --devoteItems[14] = { 2760, 17, 78 }; --Zhambra: Rope, Wooden shield, Short sword
@@ -102,16 +102,16 @@ local M = {}
 ----These are the items I need to become a priest. Not relevant for now since there is no priest magic.
 --local priestItems = {};
 --priestItems[1] = { 2416, 40, 26, 726, 735 }; --Ushara: Brown priest robe, Cleric's staff, Clay, Coarse sand, Raw stone
---priestItems[2] = { 2419, 40, 391, 46, 234 }; --Brï¿½gon: Red priest robe, Cleric's staff, Torch, Ruby, Gold nugget
+--priestItems[2] = { 2419, 40, 391, 46, 234 }; --Brágon: Red priest robe, Cleric's staff, Torch, Ruby, Gold nugget
 --priestItems[3] = { 2418, 40, 41, 285, 463 }; --Eldan: Grey priest robe, Cleric's staff, Glass ingot, Diamond, Quill
 --priestItems[4] = { 193, 40, 2496, 284, 279 }; --Tanora: Blue robe, Cleric's staff, Bottle of Water, Sapphire, Sapphire ring
 --priestItems[5] = { 2421, 40, 2780, 322, 166 }; --Findari: White priest robe, Cleric's staff, Longbow, Wind arrow, Big empty bottle
---priestItems[6] = { 2418, 445, 355, 225, 290 }; --Nargï¿½n: Grey priest robe, Wooden sword, Salmon, Crown, Cabbage
+--priestItems[6] = { 2418, 445, 355, 225, 290 }; --Nargùn: Grey priest robe, Wooden sword, Salmon, Crown, Cabbage
 --priestItems[7] = { 368, 76, 397, 3110, 222 }; --Elara: Yellow priest robe, Mage's staff, Oil lamp, Pell, Amulet
 --priestItems[8] = { 2419, 224, 335, 2744, 155 }; --Adron: Red priest robe, Golden goblet, Lute, Pipe, Sibanac leaf
 --priestItems[9] = { 2416, 271, 126, 56, 249 }; --Oldra: Brown priest robe, Scythe, Sickle, Bough, Bundle of grain
 --priestItems[10] = { 2420, 271, 138, 314, 726 }; --Cherga: Black priest robe, Scythe, Night angels blossom, potash, Coarse sand
---priestItems[11] = { 2421, 20, 391, 2291, 78 }; --Malachï¿½n: White priest robe, Large metal shield, Torch, Salkamaerian Paladin's helmet, Shortsword
+--priestItems[11] = { 2421, 20, 391, 2291, 78 }; --Malachín: White priest robe, Large metal shield, Torch, Salkamaerian Paladin's helmet, Shortsword
 --priestItems[12] = { 2418, 226, 74, 2763, 2752 }; --Irmorom: Grey priest robe, War Hammer, Hatchet, Pickaxe, Carving tools
 --priestItems[13] = { 2421, 40, 280, 354, 222 }; --Sirani: White priest robe, Cleric's staff, Diamond ring, Strawberry cake, Amulet
 --priestItems[14] = { 368, 20, 2701, 40, 333 }; --Zhambra: Yellow priest robe, Large metal shield, Longsword, Cleric's staff, Horn
@@ -176,7 +176,7 @@ local function canDevote(User, god)
     if not checkItems(User, gods.getItemsForDevotion(User, god)) then
         result = false
         reason_en = reason_en .. "You don't have the required items. "
-        reason_de = reason_de .. "Du hast nicht die geforderten Gegenstï¿½nde. "
+        reason_de = reason_de .. "Du hast nicht die geforderten Gegenstände. "
     end
 
     return result, reason_de, reason_en
@@ -186,8 +186,7 @@ local function doDevote(User, god)
     local candevote, reason_de, reason_en = canDevote(User, god)
     if not candevote then
         -- Was capable when opened dialog, but not when accepted. Cheater?
-        common.InformNLS(User, "Du erfï¿½llst nicht die Bedingungen, die an einen Anhï¿½nger gestellt werden. " .. reason_de, "You do not satisfy the devotion criteria. " .. reason_en)
-        return
+        common.InformNLS(User, "Du erfüllst nicht die Bedingungen, die an einen Anhänger gestellt werden. " .. reason_de, "You do not satisfy the devotion criteria. " .. reason_en)
     end
     deleteItems(User, gods.getItemsForDevotion(User, god))
     gods.setDevoted(User, god)
@@ -200,28 +199,28 @@ local function devotionDialog(User, god)
         return
     elseif gods.isPriest(User) then
         explanation = explanation .. common.GetNLS(User,
-            "Als Priester einer anderen Gottheit mï¿½sstest du deiner Gottheit abschwï¿½ren, um ein Priester " .. gods.getNameDe(god) .. "s zu werden. Du wï¿½rdest ebenso deinen Status als Anhï¿½nger verlieren.",
+            "Als Priester einer anderen Gottheit müsstest du deiner Gottheit abschwören, um ein Priester " .. gods.getNameDe(god) .. "s zu werden. Du würdest ebenso deinen Status als Anhänger verlieren.",
             "As priest of another god, you'll have to abjure your god to devote yourself to " .. gods.getNameEn(god) .. ", and you will lose your status."
         )
     elseif gods.isDevoted(User) then
         explanation = explanation .. common.GetNLS(User,
-            "Als Anhï¿½nger einer anderen Gottheit wirst du deinem Gott abschwï¿½ren mï¿½ssen, um dich " .. gods.getNameDe(god) .. " zu weihen.",
+            "Als Anhänger einer anderen Gottheit wirst du deinem Gott abschwören müssen, um dich " .. gods.getNameDe(god) .. " zu weihen.",
             "As devotee of another god, you'll have to abjure your god to devote yourself to " .. gods.getNameEn(god) .. "."
         )
     else -- noob
-        explanation = explanation .. common.GetNLS(User, "Du kannst nur Anhï¿½nger eines Gottes sein. Abschwï¿½ren verï¿½rgert deine Gottheit.", "You can only devote yourself to one god at a time, and abjuration will make your god angry.")
+        explanation = explanation .. common.GetNLS(User, "Du kannst nur Anhänger eines Gottes sein. Abschwören verärgert deine Gottheit.", "You can only devote yourself to one god at a time, and abjuration will make your god angry.")
     end
-    explanation = explanation .. common.GetNLS(User, "\nSpende diese Gegenstï¿½nde: " .. tellItems(User, gods.getItemsForDevotion(User, god)) .. "." , "\nYou will need to donate " .. tellItems(User, gods.getItemsForDevotion(User, god)) .. ".")
+    explanation = explanation .. common.GetNLS(User, "\nSpende diese Gegenstände: " .. tellItems(User, gods.getItemsForDevotion(User, god)) .. "." , "\nYou will need to donate " .. tellItems(User, gods.getItemsForDevotion(User, god)) .. ".")
 
     local candevote, reason_de, reason_en = canDevote(User, god)
     if candevote then
-        common.selectionDialogWrapper(User, common.GetNLS(User, "Anhï¿½ngerschaft", "Devotion"), explanation, {
-            { icon = 0, text = common.GetNLS(User, "Erklï¿½re dich zum Anhï¿½nger von " .. gods.getNameDe(god), "Devote yourself to " .. gods.getNameEn(god)), func = doDevote, args = { User, god } },
+        common.selectionDialogWrapper(User, common.GetNLS(User, "Anhängerschaft", "Devotion"), explanation, {
+            { icon = 0, text = common.GetNLS(User, "Erkläre dich zum Anhänger von " .. gods.getNameDe(god), "Devote yourself to " .. gods.getNameEn(god)), func = doDevote, args = { User, god } },
             { icon = 0, text = common.GetNLS(User, "Bleibe " .. gods.getCharStatusDe(User), "Remain " .. gods.getCharStatusEn(User)), func = nil, args = nil },
         })
     else
         explanation = explanation .. "\n" .. common.GetNLS(User, reason_de, reason_en)
-        local dialog = MessageDialog(common.GetNLS(User, "Anhï¿½ngerschaft", "Devotion"), explanation, --[[callback=]]function(d) end)
+        local dialog = MessageDialog(common.GetNLS(User, "Anhängerschaft", "Devotion"), explanation, --[[callback=]]function(d) end)
         User:requestMessageDialog(dialog)
     end
 end
@@ -229,7 +228,7 @@ end
 
 local function sacrificeExplanation(User, god)
     local explanation = common.GetNLS(User,
-        "Um Items an deinen Gott zu opfern, platziere sie auf dem Boden, nahe des Altars. Falls deine Gabe dem Gott gefï¿½llt, wird sie angenommen. Andernfalls kannst du sie zurï¿½cknehmen und etwas andere, passenderes, ausprobieren.",
+        "Um Items an deinen Gott zu opfern, platziere sie auf dem Boden, nahe des Altars. Falls deine Gabe dem Gott gefällt, wird sie angenommen. Andernfalls kannst du sie zurücknehmen und etwas andere, passenderes, ausprobieren.",
         "To sacrifice items to your god, place them on the ground near the altar. If your offer pleases the god it will be accepted, otherwise you'll be able to take it back and try something more fitting."
     )
     local dialog = MessageDialog(common.GetNLS(User, "Opfergabe", "Sacrifice"), explanation, --[[callback=]]function(d) end)
@@ -268,19 +267,19 @@ end
 --                      elseif User:getMagicType()== 3 and User:getMagicFlags(3)~= 0 then --a druid! Can't become priest
 --                        common.InformNLS(User,"Ein Druide kann leider kein Priester werden.","As a druid, you cannot become a priest anymore.");
 --                      else --a noob, may become priest
---                        common.InformNLS(User,"Um ein Priester "..godName[god].."s zu werden, wirst du folgendes opfern mï¿½ssen:","To become a priest of "..godName[god]..", you'll have to donate:");
+--                        common.InformNLS(User,"Um ein Priester "..godName[god].."s zu werden, wirst du folgendes opfern müssen:","To become a priest of "..godName[god]..", you'll have to donate:");
 --                        User:inform(tellStuff(priestItems[god],User:getPlayerLanguage())); --stuff4priest
 --                      end
 --                ]]
 --            elseif devotion ~= god then
 --                -- devoted to another god
 --                if (priesthood == 0) then
---                    common.InformNLS(User, "Als Anhï¿½nger einer anderen Gottheit wirst du deinem Gott abschwï¿½ren mï¿½ssen, um dich " .. gods.getNameDe(god) .. " zu weihen.", "As devotee of another god, you'll have to abjure your god to devote yourself to " .. gods.getNameEn(god) .. ".");
---                    common.InformNLS(User, "Um dich " .. gods.getNameDe(god) .. " zu weihen, wirst du folgendes opfern mï¿½ssen:", "To devote yourself to " .. gods.getNameEn(god) .. ", you'll have to donate:");
+--                    common.InformNLS(User, "Als Anhänger einer anderen Gottheit wirst du deinem Gott abschwören müssen, um dich " .. gods.getNameDe(god) .. " zu weihen.", "As devotee of another god, you'll have to abjure your god to devote yourself to " .. gods.getNameEn(god) .. ".");
+--                    common.InformNLS(User, "Um dich " .. gods.getNameDe(god) .. " zu weihen, wirst du folgendes opfern müssen:", "To devote yourself to " .. gods.getNameEn(god) .. ", you'll have to donate:");
 --                    User:inform(tellStuff(devoteItems[god], User:getPlayerLanguage())); --stuff4devotee
 --                else
---                    common.InformNLS(User, "Als Priester einer anderen Gottheit must du deiner Gottheit abschwï¿½ren, um ein Priester " .. gods.getNameDe(god) .. "s zu werden.", "As priest of another god, you'll have to abjure your god to become a priest of " .. gods.getNameEn(god) .. ".");
---                    common.InformNLS(User, "Um ein Priester " .. gods.getNameDe(god) .. "s zu werden, wirst du folgendes opfern mï¿½ssen:", "To devote yourself to " .. gods.getNameEn(god) .. ", you'll have to donate:");
+--                    common.InformNLS(User, "Als Priester einer anderen Gottheit must du deiner Gottheit abschwören, um ein Priester " .. gods.getNameDe(god) .. "s zu werden.", "As priest of another god, you'll have to abjure your god to become a priest of " .. gods.getNameEn(god) .. ".");
+--                    common.InformNLS(User, "Um ein Priester " .. gods.getNameDe(god) .. "s zu werden, wirst du folgendes opfern müssen:", "To devote yourself to " .. gods.getNameEn(god) .. ", you'll have to donate:");
 --                    User:inform(tellStuff(devoteItems[god], User:getPlayerLanguage())); --stuff4devotee
 --                    User:inform(tellStuff(priestItems[god], User:getPlayerLanguage())); --stuff4priest
 --                end
@@ -289,11 +288,11 @@ end
 --            elseif (devotion == god) then
 --                -- devoted to this god
 --                common.InformNLS(User,
---                    "Du betest zu " .. gods.GOD_DE[god] .. " und bekrï¿½ftigst deinen Glauben.",
+--                    "Du betest zu " .. gods.GOD_DE[god] .. " und bekräftigst deinen Glauben.",
 --                    "You pray to " .. gods.GOD_EN[god] .. " and confirm your faith.");
 --                if (priesthood == 0) then
 --                    common.InformNLS(User,
---                        "[INFO] An dieser Stelle kï¿½nntest du Priester werden, aber Priestermagie ist noch nicht verfï¿½gbar.",
+--                        "[INFO] An dieser Stelle könntest du Priester werden, aber Priestermagie ist noch nicht verfügbar.",
 --                        "[INFO] At this point you could become a priest, but priest magic is not available yet.");
 --                    --Below, even more stuff that only makes sense with priest magic. Code makes devotees become priests.
 --                    --[[
@@ -316,11 +315,11 @@ end
 --                          User:teachMagic(1,2);
 --                          User:teachMagic(1,3);
 --                        else --does not have the stuff
---                          common.InformNLS(User,"Um ein Priester "..godName[god].."s zu werden, wirst du folgendes opfern mï¿½ssen:","To become a priest of "..godName[god]..", you'll have to donate:");
+--                          common.InformNLS(User,"Um ein Priester "..godName[god].."s zu werden, wirst du folgendes opfern müssen:","To become a priest of "..godName[god]..", you'll have to donate:");
 --                        end --item check
 --                        User:inform(tellStuff(priestItems[god],User:getPlayerLanguage())); --stuff4priest
 --                      else --not enough devotees around
---                        common.InformNLS(User,"Um die Priesterweihe zu empfangen musst du wenigstens drei Anhï¿½nger "..godName[god].."s zu einer Messe versammeln.","To receive the ordination to the priesthood of "..godName[god]..", you'll have to gather at least three devotees for a mass.");
+--                        common.InformNLS(User,"Um die Priesterweihe zu empfangen musst du wenigstens drei Anhänger "..godName[god].."s zu einer Messe versammeln.","To receive the ordination to the priesthood of "..godName[god]..", you'll have to gather at least three devotees for a mass.");
 --                      end --audience check
 --                    end --noob
 --                    --]]
@@ -342,28 +341,28 @@ local function ZeniaAltar(User, SourceItem)
 
     if User:getQuestProgress(502) == 1 then
         User:setQuestProgress(502, 2) --Prayer done
-        User:inform("[Quest status] Du hast gebetet und hoffentlich Zenia damit erfreut. Kehre zu ihr zurï¿½ck", "[Quest status] You feel as if you have prayed sufficient to please Zenia. Please return to her.")
+        User:inform("[Quest status] Du hast gebetet und hoffentlich Zenia damit erfreut. Kehre zu ihr zurück", "[Quest status] You feel as if you have prayed sufficient to please Zenia. Please return to her.")
     elseif User:getQuestProgress(502) == 8 and User:countItemAt("all", 2760) >= 2 and User:countItemAt("all", 3) >= 5 and User:countItemAt("all", 26) >= 5 and User:countItemAt("all", 73) >= 10 then -- Take raft items
         User:eraseItem(2760, 2)
         User:eraseItem(3, 5)
         User:eraseItem(26, 5)
         User:eraseItem(73, 10)
         User:setQuestProgress(502, 9) --  You made a raft.
-        User:inform("[Quest status] Nach dem Gebet siehst du, wie die Materialien sich von selbst zu einem kleinen Floss zusammenfï¿½gen. Du kletterst darauf und wirst zu einer kleinen Insel transportiert.", "[Quest status] After praying, you see the items magicallyï¿½form a small raft.  You climb on board and are transported to a small island.")
+        User:inform("[Quest status] Nach dem Gebet siehst du, wie die Materialien sich von selbst zu einem kleinen Floss zusammenfügen. Du kletterst darauf und wirst zu einer kleinen Insel transportiert.", "[Quest status] After praying, you see the items magically form a small raft.  You climb on board and are transported to a small island.")
         User:warp(position(753, 351, -9))
         world:gfx(11, User.pos)
         world:makeSound(9, User.pos)
     elseif User:getQuestProgress(502) == 8 then -- You dropped something you needed.
-        User:inform("Du musst alle Einzelteile fï¿½r Floï¿½ und Gebet haben.", "You need all items for raft and prayer.")
+        User:inform("Du musst alle Einzelteile für Floß und Gebet haben.", "You need all items for raft and prayer.")
     elseif User:getQuestProgress(502) == 10 and User:countItemAt("all",355) >= 10 then -- Revisit Zenia
         User:eraseItem(355, 10)
         User:setQuestProgress(502, 9) --  Ready to leave again.
-        User:inform("[Quest status] Nach dem Gebet siehst du einen hellen Lichtblitz und das kleine Floss erscheint im Wasser. Nachdem du darauf geklettert bist, wirst du zurï¿½ck auf die kleine Insel gebracht.", "[Quest status]  After praying,ï¿½you see a bright light flash and your small raft magicallyï¿½appears in the water. Climbing onto it, you are transported back to the small island.")
+        User:inform("[Quest status] Nach dem Gebet siehst du einen hellen Lichtblitz und das kleine Floss erscheint im Wasser. Nachdem du darauf geklettert bist, wirst du zurück auf die kleine Insel gebracht.", "[Quest status]  After praying, you see a bright light flash and your small raft magically appears in the water. Climbing onto it, you are transported back to the small island.")
         User:warp(position(753, 351, -9))
         world:gfx(11, User.pos)
         world:makeSound(9, User.pos)
     elseif  User:getQuestProgress(502) == 10 then -- You dropped something you needed.
-        User:inform("Du hast nicht die richtigen Dinge fï¿½r das Gebet.", "You lack the proper items for prayer.")
+        User:inform("Du hast nicht die richtigen Dinge für das Gebet.", "You lack the proper items for prayer.")
     end
 end
 
@@ -378,7 +377,7 @@ function M.LookAtItem(User, Item)
         local msg_en = "Altar of " .. gods.getNameEn(god) .. ", the " .. gods.getDescriptionEn(god) .. "."
         local msg_de = "Altar " .. gods.getNameDe(god) .. "s, " .. gods.getDescriptionDe(god) .. "."
         if gods.isDevoted(User, god) then
-            lookat.SetSpecialDescription(Item, "Der Anblick von " .. gods.getNameDe(god) .. "s Altar erfï¿½llt dich in deiner Ergebenheit mit Stolz.", "Beholding the altar of " .. gods.getNameEn(god) .. " makes you feel proud of your devotion.")
+            lookat.SetSpecialDescription(Item, "Der Anblick von " .. gods.getNameDe(god) .. "s Altar erfüllt dich in deiner Ergebenheit mit Stolz.", "Beholding the altar of " .. gods.getNameEn(god) .. " makes you feel proud of your devotion.")
         end
         lookat.SetSpecialName(Item,
             msg_de,
@@ -416,7 +415,7 @@ function M.UseItem(User, SourceItem, ltstate)
 
     --Depending on who's altar that is and who uses it, execute different actions
     if not gods.GODS[god] then --undedicated altar
-        common.InformNLS(User, "Du berï¿½hrst den Altar, die Abwesenheit gï¿½ttlichen Wirkens ist offensichtlich.", "You touch the altar, the absence of divine blessing is obvious.");
+        common.InformNLS(User, "Du berührst den Altar, die Abwesenheit göttlichen Wirkens ist offensichtlich.", "You touch the altar, the absence of divine blessing is obvious.");
     else --dedicated altar
         
         local title = common.GetNLS(User,
@@ -424,7 +423,7 @@ function M.UseItem(User, SourceItem, ltstate)
             "Altar of " .. gods.getNameEn(god)
         )
         local description = common.GetNLS(User,
-            "Altar " .. gods.getNameDe(god) .. "s, " .. gods.getDescriptionDe(god) .. ".\nWï¿½hle eine Aktion:",
+            "Altar " .. gods.getNameDe(god) .. "s, " .. gods.getDescriptionDe(god) .. ".\nWähle eine Aktion:",
             "Altar of " .. gods.getNameEn(god) .. ", the " .. gods.getDescriptionEn(god) .. ".\nChoose your action:"
         )
         local dialogOptions = {

--- a/item/altars.lua
+++ b/item/altars.lua
@@ -20,17 +20,17 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
 -- REFERENCE_IN_LUA - DATA - MEANING
 --Elder Gods
 -- gods.GOD_USHARA   -  1 - Ushara - Goddess of earth
--- gods.GOD_BRAGON   -  2 - Brágon - God of fire
+-- gods.GOD_BRAGON   -  2 - Brï¿½gon - God of fire
 -- gods.GOD_ELDAN    -  3 - Eldan - God of spirit
 -- gods.GOD_TANORA   -  4 - Tanora/Zelphia - Goddess of water
 -- gods.GOD_FINDARI  -  5 - Findari - Goddess of air
 --Younger Gods
--- gods.GOD_NARGUN   -  6 - Nargùn - God of chaos
+-- gods.GOD_NARGUN   -  6 - Nargï¿½n - God of chaos
 -- gods.GOD_ELARA    -  7 - Elara - Goddess of wisdom and knowledge
 -- gods.GOD_ADRON    -  8 - Adron - God of festivities and wine
 -- gods.GOD_OLDRA    -  9 - Oldra - Goddess of life and fertility
 -- gods.GOD_CHERGA   - 10 - Cherga - Goddess of spirits and the underworld
--- gods.GOD_MALACHIN - 11 - Malachín - God of battle and hunting
+-- gods.GOD_MALACHIN - 11 - Malachï¿½n - God of battle and hunting
 -- gods.GOD_IRMOROM  - 12 - Irmorom - God of trade and craftsmanship
 -- gods.GOD_SIRANI   - 13 - Sirani - Goddess of love and pleasure
 -- gods.GOD_ZHAMBRA  - 14 - Zhambra - God of friendship and loyalty
@@ -83,16 +83,16 @@ local M = {}
 ----These are the items I need to become a devotee
 --local devoteItems = {};
 --devoteItems[1] = { 733, 316, 2588 }; --Ushara: Stone block, Quartz sand, Brick
---devoteItems[2] = { 314, 236, 43 }; --Brágon: potash, Gold ignot, Candle
+--devoteItems[2] = { 314, 236, 43 }; --Brï¿½gon: potash, Gold ignot, Candle
 --devoteItems[3] = { 256, 2745, 155 }; --Eldan: Raw diamonds, Parchment, Sibanac leaf
 --devoteItems[4] = { 52, 253, 72 }; --Tanora: Bucket of water, Raw sapphire, Fishing rod
 --devoteItems[5] = { 64, 463, 65 }; --Findari: Arrow, Quill, Short Bow
---devoteItems[6] = { 80, 356, 733 }; --Nargùn: Banana, Slouch hat, Stone block
+--devoteItems[6] = { 80, 356, 733 }; --Nargï¿½n: Banana, Slouch hat, Stone block
 --devoteItems[7] = { 2745, 43, 463 }; --Elara: Parchment, Candle, Quill
 --devoteItems[8] = { 223, 2500, 388 }; --Adron: Iron Goblet, Bottle of Wine, Grapes
 --devoteItems[9] = { 258, 534, 259 }; --Oldra: Flail, Onion seeds, Grain
 --devoteItems[10] = { 24, 43, 182 }; --Cherga: Shovel, Candle, Black shirt
---devoteItems[11] = { 19, 65, 2586 }; --Malachín: Metal shield, Short bow, Fur
+--devoteItems[11] = { 19, 65, 2586 }; --Malachï¿½n: Metal shield, Short bow, Fur
 --devoteItems[12] = { 3077, 23, 2140 }; --Irmorom: Silver coin, Hammer, Tongs
 --devoteItems[13] = { 235, 148, 174 }; --Sirani: Gold ring, Firnis blossom, Red cloth
 --devoteItems[14] = { 2760, 17, 78 }; --Zhambra: Rope, Wooden shield, Short sword
@@ -102,16 +102,16 @@ local M = {}
 ----These are the items I need to become a priest. Not relevant for now since there is no priest magic.
 --local priestItems = {};
 --priestItems[1] = { 2416, 40, 26, 726, 735 }; --Ushara: Brown priest robe, Cleric's staff, Clay, Coarse sand, Raw stone
---priestItems[2] = { 2419, 40, 391, 46, 234 }; --Brágon: Red priest robe, Cleric's staff, Torch, Ruby, Gold nugget
+--priestItems[2] = { 2419, 40, 391, 46, 234 }; --Brï¿½gon: Red priest robe, Cleric's staff, Torch, Ruby, Gold nugget
 --priestItems[3] = { 2418, 40, 41, 285, 463 }; --Eldan: Grey priest robe, Cleric's staff, Glass ingot, Diamond, Quill
 --priestItems[4] = { 193, 40, 2496, 284, 279 }; --Tanora: Blue robe, Cleric's staff, Bottle of Water, Sapphire, Sapphire ring
 --priestItems[5] = { 2421, 40, 2780, 322, 166 }; --Findari: White priest robe, Cleric's staff, Longbow, Wind arrow, Big empty bottle
---priestItems[6] = { 2418, 445, 355, 225, 290 }; --Nargùn: Grey priest robe, Wooden sword, Salmon, Crown, Cabbage
+--priestItems[6] = { 2418, 445, 355, 225, 290 }; --Nargï¿½n: Grey priest robe, Wooden sword, Salmon, Crown, Cabbage
 --priestItems[7] = { 368, 76, 397, 3110, 222 }; --Elara: Yellow priest robe, Mage's staff, Oil lamp, Pell, Amulet
 --priestItems[8] = { 2419, 224, 335, 2744, 155 }; --Adron: Red priest robe, Golden goblet, Lute, Pipe, Sibanac leaf
 --priestItems[9] = { 2416, 271, 126, 56, 249 }; --Oldra: Brown priest robe, Scythe, Sickle, Bough, Bundle of grain
 --priestItems[10] = { 2420, 271, 138, 314, 726 }; --Cherga: Black priest robe, Scythe, Night angels blossom, potash, Coarse sand
---priestItems[11] = { 2421, 20, 391, 2291, 78 }; --Malachín: White priest robe, Large metal shield, Torch, Salkamaerian Paladin's helmet, Shortsword
+--priestItems[11] = { 2421, 20, 391, 2291, 78 }; --Malachï¿½n: White priest robe, Large metal shield, Torch, Salkamaerian Paladin's helmet, Shortsword
 --priestItems[12] = { 2418, 226, 74, 2763, 2752 }; --Irmorom: Grey priest robe, War Hammer, Hatchet, Pickaxe, Carving tools
 --priestItems[13] = { 2421, 40, 280, 354, 222 }; --Sirani: White priest robe, Cleric's staff, Diamond ring, Strawberry cake, Amulet
 --priestItems[14] = { 368, 20, 2701, 40, 333 }; --Zhambra: Yellow priest robe, Large metal shield, Longsword, Cleric's staff, Horn
@@ -176,7 +176,7 @@ local function canDevote(User, god)
     if not checkItems(User, gods.getItemsForDevotion(User, god)) then
         result = false
         reason_en = reason_en .. "You don't have the required items. "
-        reason_de = reason_de .. "Du hast nicht die geforderten Gegenstände. "
+        reason_de = reason_de .. "Du hast nicht die geforderten Gegenstï¿½nde. "
     end
 
     return result, reason_de, reason_en
@@ -186,7 +186,8 @@ local function doDevote(User, god)
     local candevote, reason_de, reason_en = canDevote(User, god)
     if not candevote then
         -- Was capable when opened dialog, but not when accepted. Cheater?
-        common.InformNLS(User, "Du erfüllst nicht die Bedingungen, die an einen Anhänger gestellt werden. " .. reason_de, "You do not satisfy the devotion criteria. " .. reason_en)
+        common.InformNLS(User, "Du erfï¿½llst nicht die Bedingungen, die an einen Anhï¿½nger gestellt werden. " .. reason_de, "You do not satisfy the devotion criteria. " .. reason_en)
+        return
     end
     deleteItems(User, gods.getItemsForDevotion(User, god))
     gods.setDevoted(User, god)
@@ -199,28 +200,28 @@ local function devotionDialog(User, god)
         return
     elseif gods.isPriest(User) then
         explanation = explanation .. common.GetNLS(User,
-            "Als Priester einer anderen Gottheit müsstest du deiner Gottheit abschwören, um ein Priester " .. gods.getNameDe(god) .. "s zu werden. Du würdest ebenso deinen Status als Anhänger verlieren.",
+            "Als Priester einer anderen Gottheit mï¿½sstest du deiner Gottheit abschwï¿½ren, um ein Priester " .. gods.getNameDe(god) .. "s zu werden. Du wï¿½rdest ebenso deinen Status als Anhï¿½nger verlieren.",
             "As priest of another god, you'll have to abjure your god to devote yourself to " .. gods.getNameEn(god) .. ", and you will lose your status."
         )
     elseif gods.isDevoted(User) then
         explanation = explanation .. common.GetNLS(User,
-            "Als Anhänger einer anderen Gottheit wirst du deinem Gott abschwören müssen, um dich " .. gods.getNameDe(god) .. " zu weihen.",
+            "Als Anhï¿½nger einer anderen Gottheit wirst du deinem Gott abschwï¿½ren mï¿½ssen, um dich " .. gods.getNameDe(god) .. " zu weihen.",
             "As devotee of another god, you'll have to abjure your god to devote yourself to " .. gods.getNameEn(god) .. "."
         )
     else -- noob
-        explanation = explanation .. common.GetNLS(User, "Du kannst nur Anhänger eines Gottes sein. Abschwören verärgert deine Gottheit.", "You can only devote yourself to one god at a time, and abjuration will make your god angry.")
+        explanation = explanation .. common.GetNLS(User, "Du kannst nur Anhï¿½nger eines Gottes sein. Abschwï¿½ren verï¿½rgert deine Gottheit.", "You can only devote yourself to one god at a time, and abjuration will make your god angry.")
     end
-    explanation = explanation .. common.GetNLS(User, "\nSpende diese Gegenstände: " .. tellItems(User, gods.getItemsForDevotion(User, god)) .. "." , "\nYou will need to donate " .. tellItems(User, gods.getItemsForDevotion(User, god)) .. ".")
+    explanation = explanation .. common.GetNLS(User, "\nSpende diese Gegenstï¿½nde: " .. tellItems(User, gods.getItemsForDevotion(User, god)) .. "." , "\nYou will need to donate " .. tellItems(User, gods.getItemsForDevotion(User, god)) .. ".")
 
     local candevote, reason_de, reason_en = canDevote(User, god)
     if candevote then
-        common.selectionDialogWrapper(User, common.GetNLS(User, "Anhängerschaft", "Devotion"), explanation, {
-            { icon = 0, text = common.GetNLS(User, "Erkläre dich zum Anhänger von " .. gods.getNameDe(god), "Devote yourself to " .. gods.getNameEn(god)), func = doDevote, args = { User, god } },
+        common.selectionDialogWrapper(User, common.GetNLS(User, "Anhï¿½ngerschaft", "Devotion"), explanation, {
+            { icon = 0, text = common.GetNLS(User, "Erklï¿½re dich zum Anhï¿½nger von " .. gods.getNameDe(god), "Devote yourself to " .. gods.getNameEn(god)), func = doDevote, args = { User, god } },
             { icon = 0, text = common.GetNLS(User, "Bleibe " .. gods.getCharStatusDe(User), "Remain " .. gods.getCharStatusEn(User)), func = nil, args = nil },
         })
     else
         explanation = explanation .. "\n" .. common.GetNLS(User, reason_de, reason_en)
-        local dialog = MessageDialog(common.GetNLS(User, "Anhängerschaft", "Devotion"), explanation, --[[callback=]]function(d) end)
+        local dialog = MessageDialog(common.GetNLS(User, "Anhï¿½ngerschaft", "Devotion"), explanation, --[[callback=]]function(d) end)
         User:requestMessageDialog(dialog)
     end
 end
@@ -228,7 +229,7 @@ end
 
 local function sacrificeExplanation(User, god)
     local explanation = common.GetNLS(User,
-        "Um Items an deinen Gott zu opfern, platziere sie auf dem Boden, nahe des Altars. Falls deine Gabe dem Gott gefällt, wird sie angenommen. Andernfalls kannst du sie zurücknehmen und etwas andere, passenderes, ausprobieren.",
+        "Um Items an deinen Gott zu opfern, platziere sie auf dem Boden, nahe des Altars. Falls deine Gabe dem Gott gefï¿½llt, wird sie angenommen. Andernfalls kannst du sie zurï¿½cknehmen und etwas andere, passenderes, ausprobieren.",
         "To sacrifice items to your god, place them on the ground near the altar. If your offer pleases the god it will be accepted, otherwise you'll be able to take it back and try something more fitting."
     )
     local dialog = MessageDialog(common.GetNLS(User, "Opfergabe", "Sacrifice"), explanation, --[[callback=]]function(d) end)
@@ -267,19 +268,19 @@ end
 --                      elseif User:getMagicType()== 3 and User:getMagicFlags(3)~= 0 then --a druid! Can't become priest
 --                        common.InformNLS(User,"Ein Druide kann leider kein Priester werden.","As a druid, you cannot become a priest anymore.");
 --                      else --a noob, may become priest
---                        common.InformNLS(User,"Um ein Priester "..godName[god].."s zu werden, wirst du folgendes opfern müssen:","To become a priest of "..godName[god]..", you'll have to donate:");
+--                        common.InformNLS(User,"Um ein Priester "..godName[god].."s zu werden, wirst du folgendes opfern mï¿½ssen:","To become a priest of "..godName[god]..", you'll have to donate:");
 --                        User:inform(tellStuff(priestItems[god],User:getPlayerLanguage())); --stuff4priest
 --                      end
 --                ]]
 --            elseif devotion ~= god then
 --                -- devoted to another god
 --                if (priesthood == 0) then
---                    common.InformNLS(User, "Als Anhänger einer anderen Gottheit wirst du deinem Gott abschwören müssen, um dich " .. gods.getNameDe(god) .. " zu weihen.", "As devotee of another god, you'll have to abjure your god to devote yourself to " .. gods.getNameEn(god) .. ".");
---                    common.InformNLS(User, "Um dich " .. gods.getNameDe(god) .. " zu weihen, wirst du folgendes opfern müssen:", "To devote yourself to " .. gods.getNameEn(god) .. ", you'll have to donate:");
+--                    common.InformNLS(User, "Als Anhï¿½nger einer anderen Gottheit wirst du deinem Gott abschwï¿½ren mï¿½ssen, um dich " .. gods.getNameDe(god) .. " zu weihen.", "As devotee of another god, you'll have to abjure your god to devote yourself to " .. gods.getNameEn(god) .. ".");
+--                    common.InformNLS(User, "Um dich " .. gods.getNameDe(god) .. " zu weihen, wirst du folgendes opfern mï¿½ssen:", "To devote yourself to " .. gods.getNameEn(god) .. ", you'll have to donate:");
 --                    User:inform(tellStuff(devoteItems[god], User:getPlayerLanguage())); --stuff4devotee
 --                else
---                    common.InformNLS(User, "Als Priester einer anderen Gottheit must du deiner Gottheit abschwören, um ein Priester " .. gods.getNameDe(god) .. "s zu werden.", "As priest of another god, you'll have to abjure your god to become a priest of " .. gods.getNameEn(god) .. ".");
---                    common.InformNLS(User, "Um ein Priester " .. gods.getNameDe(god) .. "s zu werden, wirst du folgendes opfern müssen:", "To devote yourself to " .. gods.getNameEn(god) .. ", you'll have to donate:");
+--                    common.InformNLS(User, "Als Priester einer anderen Gottheit must du deiner Gottheit abschwï¿½ren, um ein Priester " .. gods.getNameDe(god) .. "s zu werden.", "As priest of another god, you'll have to abjure your god to become a priest of " .. gods.getNameEn(god) .. ".");
+--                    common.InformNLS(User, "Um ein Priester " .. gods.getNameDe(god) .. "s zu werden, wirst du folgendes opfern mï¿½ssen:", "To devote yourself to " .. gods.getNameEn(god) .. ", you'll have to donate:");
 --                    User:inform(tellStuff(devoteItems[god], User:getPlayerLanguage())); --stuff4devotee
 --                    User:inform(tellStuff(priestItems[god], User:getPlayerLanguage())); --stuff4priest
 --                end
@@ -288,11 +289,11 @@ end
 --            elseif (devotion == god) then
 --                -- devoted to this god
 --                common.InformNLS(User,
---                    "Du betest zu " .. gods.GOD_DE[god] .. " und bekräftigst deinen Glauben.",
+--                    "Du betest zu " .. gods.GOD_DE[god] .. " und bekrï¿½ftigst deinen Glauben.",
 --                    "You pray to " .. gods.GOD_EN[god] .. " and confirm your faith.");
 --                if (priesthood == 0) then
 --                    common.InformNLS(User,
---                        "[INFO] An dieser Stelle könntest du Priester werden, aber Priestermagie ist noch nicht verfügbar.",
+--                        "[INFO] An dieser Stelle kï¿½nntest du Priester werden, aber Priestermagie ist noch nicht verfï¿½gbar.",
 --                        "[INFO] At this point you could become a priest, but priest magic is not available yet.");
 --                    --Below, even more stuff that only makes sense with priest magic. Code makes devotees become priests.
 --                    --[[
@@ -315,11 +316,11 @@ end
 --                          User:teachMagic(1,2);
 --                          User:teachMagic(1,3);
 --                        else --does not have the stuff
---                          common.InformNLS(User,"Um ein Priester "..godName[god].."s zu werden, wirst du folgendes opfern müssen:","To become a priest of "..godName[god]..", you'll have to donate:");
+--                          common.InformNLS(User,"Um ein Priester "..godName[god].."s zu werden, wirst du folgendes opfern mï¿½ssen:","To become a priest of "..godName[god]..", you'll have to donate:");
 --                        end --item check
 --                        User:inform(tellStuff(priestItems[god],User:getPlayerLanguage())); --stuff4priest
 --                      else --not enough devotees around
---                        common.InformNLS(User,"Um die Priesterweihe zu empfangen musst du wenigstens drei Anhänger "..godName[god].."s zu einer Messe versammeln.","To receive the ordination to the priesthood of "..godName[god]..", you'll have to gather at least three devotees for a mass.");
+--                        common.InformNLS(User,"Um die Priesterweihe zu empfangen musst du wenigstens drei Anhï¿½nger "..godName[god].."s zu einer Messe versammeln.","To receive the ordination to the priesthood of "..godName[god]..", you'll have to gather at least three devotees for a mass.");
 --                      end --audience check
 --                    end --noob
 --                    --]]
@@ -341,28 +342,28 @@ local function ZeniaAltar(User, SourceItem)
 
     if User:getQuestProgress(502) == 1 then
         User:setQuestProgress(502, 2) --Prayer done
-        User:inform("[Quest status] Du hast gebetet und hoffentlich Zenia damit erfreut. Kehre zu ihr zurück", "[Quest status] You feel as if you have prayed sufficient to please Zenia. Please return to her.")
+        User:inform("[Quest status] Du hast gebetet und hoffentlich Zenia damit erfreut. Kehre zu ihr zurï¿½ck", "[Quest status] You feel as if you have prayed sufficient to please Zenia. Please return to her.")
     elseif User:getQuestProgress(502) == 8 and User:countItemAt("all", 2760) >= 2 and User:countItemAt("all", 3) >= 5 and User:countItemAt("all", 26) >= 5 and User:countItemAt("all", 73) >= 10 then -- Take raft items
         User:eraseItem(2760, 2)
         User:eraseItem(3, 5)
         User:eraseItem(26, 5)
         User:eraseItem(73, 10)
         User:setQuestProgress(502, 9) --  You made a raft.
-        User:inform("[Quest status] Nach dem Gebet siehst du, wie die Materialien sich von selbst zu einem kleinen Floss zusammenfügen. Du kletterst darauf und wirst zu einer kleinen Insel transportiert.", "[Quest status] After praying, you see the items magically form a small raft.  You climb on board and are transported to a small island.")
+        User:inform("[Quest status] Nach dem Gebet siehst du, wie die Materialien sich von selbst zu einem kleinen Floss zusammenfï¿½gen. Du kletterst darauf und wirst zu einer kleinen Insel transportiert.", "[Quest status] After praying, you see the items magicallyï¿½form a small raft.  You climb on board and are transported to a small island.")
         User:warp(position(753, 351, -9))
         world:gfx(11, User.pos)
         world:makeSound(9, User.pos)
     elseif User:getQuestProgress(502) == 8 then -- You dropped something you needed.
-        User:inform("Du musst alle Einzelteile für Floß und Gebet haben.", "You need all items for raft and prayer.")
+        User:inform("Du musst alle Einzelteile fï¿½r Floï¿½ und Gebet haben.", "You need all items for raft and prayer.")
     elseif User:getQuestProgress(502) == 10 and User:countItemAt("all",355) >= 10 then -- Revisit Zenia
         User:eraseItem(355, 10)
         User:setQuestProgress(502, 9) --  Ready to leave again.
-        User:inform("[Quest status] Nach dem Gebet siehst du einen hellen Lichtblitz und das kleine Floss erscheint im Wasser. Nachdem du darauf geklettert bist, wirst du zurück auf die kleine Insel gebracht.", "[Quest status]  After praying, you see a bright light flash and your small raft magically appears in the water. Climbing onto it, you are transported back to the small island.")
+        User:inform("[Quest status] Nach dem Gebet siehst du einen hellen Lichtblitz und das kleine Floss erscheint im Wasser. Nachdem du darauf geklettert bist, wirst du zurï¿½ck auf die kleine Insel gebracht.", "[Quest status]  After praying,ï¿½you see a bright light flash and your small raft magicallyï¿½appears in the water. Climbing onto it, you are transported back to the small island.")
         User:warp(position(753, 351, -9))
         world:gfx(11, User.pos)
         world:makeSound(9, User.pos)
     elseif  User:getQuestProgress(502) == 10 then -- You dropped something you needed.
-        User:inform("Du hast nicht die richtigen Dinge für das Gebet.", "You lack the proper items for prayer.")
+        User:inform("Du hast nicht die richtigen Dinge fï¿½r das Gebet.", "You lack the proper items for prayer.")
     end
 end
 
@@ -377,7 +378,7 @@ function M.LookAtItem(User, Item)
         local msg_en = "Altar of " .. gods.getNameEn(god) .. ", the " .. gods.getDescriptionEn(god) .. "."
         local msg_de = "Altar " .. gods.getNameDe(god) .. "s, " .. gods.getDescriptionDe(god) .. "."
         if gods.isDevoted(User, god) then
-            lookat.SetSpecialDescription(Item, "Der Anblick von " .. gods.getNameDe(god) .. "s Altar erfüllt dich in deiner Ergebenheit mit Stolz.", "Beholding the altar of " .. gods.getNameEn(god) .. " makes you feel proud of your devotion.")
+            lookat.SetSpecialDescription(Item, "Der Anblick von " .. gods.getNameDe(god) .. "s Altar erfï¿½llt dich in deiner Ergebenheit mit Stolz.", "Beholding the altar of " .. gods.getNameEn(god) .. " makes you feel proud of your devotion.")
         end
         lookat.SetSpecialName(Item,
             msg_de,
@@ -415,7 +416,7 @@ function M.UseItem(User, SourceItem, ltstate)
 
     --Depending on who's altar that is and who uses it, execute different actions
     if not gods.GODS[god] then --undedicated altar
-        common.InformNLS(User, "Du berührst den Altar, die Abwesenheit göttlichen Wirkens ist offensichtlich.", "You touch the altar, the absence of divine blessing is obvious.");
+        common.InformNLS(User, "Du berï¿½hrst den Altar, die Abwesenheit gï¿½ttlichen Wirkens ist offensichtlich.", "You touch the altar, the absence of divine blessing is obvious.");
     else --dedicated altar
         
         local title = common.GetNLS(User,
@@ -423,7 +424,7 @@ function M.UseItem(User, SourceItem, ltstate)
             "Altar of " .. gods.getNameEn(god)
         )
         local description = common.GetNLS(User,
-            "Altar " .. gods.getNameDe(god) .. "s, " .. gods.getDescriptionDe(god) .. ".\nWähle eine Aktion:",
+            "Altar " .. gods.getNameDe(god) .. "s, " .. gods.getDescriptionDe(god) .. ".\nWï¿½hle eine Aktion:",
             "Altar of " .. gods.getNameEn(god) .. ", the " .. gods.getDescriptionEn(god) .. ".\nChoose your action:"
         )
         local dialogOptions = {

--- a/item/altars.lua
+++ b/item/altars.lua
@@ -187,6 +187,7 @@ local function doDevote(User, god)
     if not candevote then
         -- Was capable when opened dialog, but not when accepted. Cheater?
         common.InformNLS(User, "Du erfüllst nicht die Bedingungen, die an einen Anhänger gestellt werden. " .. reason_de, "You do not satisfy the devotion criteria. " .. reason_en)
+        return
     end
     deleteItems(User, gods.getItemsForDevotion(User, god))
     gods.setDevoted(User, god)


### PR DESCRIPTION
Several gods had very short sacrifice lists, or were missing items that naturally fell into their domain. This adds many more items to Cherga, Moshran, and Oldra with small additions to Sirani and Malachin.

Oldra gains the drinks that are left off of Adron's list for being non-alcoholic, as well as all herbs in keeping with her status as a patron of druids.

Moshran gains almost all weapons and armors in keeping with his role as warlord. He also gains a multiplier for all drow and orc equipment because of his role in the creation of those races. A larger multiplier is added specifically for dragon eggs, in reference to the Moshran and Dragorog stealing eggs from Bragon and creating the evil black dragons. He also gains poisonous herbs in reference to the drow love of poison and trickery. Obsidians and obsidian jewelry are also added due to the black stone's long IG association with power at a cost and cults. Moshran also gains crowns for his role as a god of ambition. He also gains various black and red items from tailoring for the aesthetic of being the God of Blood and Bones.

Cherga gains a few specific items to fit her aesthetic as the Mistress of the Grave. These include items that may come from her less honorable followers in necromancers and executioners. she also gains many black and grey items from tailoring to fit her aesthetic as the Grey Lady.

Malachin gains arrows and bolts as the patron of hunters.