### PR TITLE
Text Improvements

### DIFF
--- a/npc/eleanor_fairbanks.npc
+++ b/npc/eleanor_fairbanks.npc
@@ -104,11 +104,11 @@ queststatus(514) = 0, "Auftrag", "Aufgabe", "Abenteuer", "Befehl"-> inform ("[Ne
 
 --Not done
 queststatus(514) = 1, item(227, all) < 1, english, ".+" -> "Have you gotten me that spoon yet?"
-queststatus(514) = 1, item(227, all) < 1, ".+" -> "Hast du mir den Kochlöffel mitgebracht?"
+queststatus(514) = 1, item(227, all) < 1, ".+" -> "Hast du mir den Löffel mitgebracht?"
 
 --done
 queststatus(514) = 1, item(227, all) > 0, english, ".+"-> inform ("[Quest Solved] You are awarded a wooden spoon."), deleteItem(227,1), item(227, 1, 566), queststatus(514) = 2, "Thank you! Now I can get this stew started! Here, why don't you take my old one. It may yet still have some use left in it."
-queststatus(514) = 1, item(227, all) > 0, ".+" -> inform ("[Quest gelöst] Du erhältst einen Kochlöffel."), deleteItem(227,1), item(227, 1, 566), queststatus(514) = 2, "Danke! Jetzt kann ich den Eintopf machen! Hier, nimm meinen alten Kochlöffel. Er könnte noch von Nutzen sein."
+queststatus(514) = 1, item(227, all) > 0, ".+" -> inform ("[Quest gelöst] Du erhältst das hölzerner Löffel."), deleteItem(227,1), item(227, 1, 566), queststatus(514) = 2, "Danke! Jetzt kann ich den Eintopf machen! Hier, nimm meinen alten Löffel. Er könnte noch von Nutzen sein."
 
 -- Quest 2: Needs 25 Cabbages, reward 30 silver
 queststatus(514) = 2, english, "quest", "mission" -> inform ("[New Quest] A Good Deed for Oldra II"), queststatus(514) = 3, "It seems I may have misread my recipe and did not buy enough cabbages the other day. Would you be so kind as to pick up the remaining twenty five for me?"

--- a/npc/eleanor_fairbanks.npc
+++ b/npc/eleanor_fairbanks.npc
@@ -104,11 +104,11 @@ queststatus(514) = 0, "Auftrag", "Aufgabe", "Abenteuer", "Befehl"-> inform ("[Ne
 
 --Not done
 queststatus(514) = 1, item(227, all) < 1, english, ".+" -> "Have you gotten me that spoon yet?"
-queststatus(514) = 1, item(227, all) < 1, ".+" -> "Hast du mir den Löffel mitgebracht?"
+queststatus(514) = 1, item(227, all) < 1, ".+" -> "Hast du mir den Kochlöffel mitgebracht?"
 
 --done
 queststatus(514) = 1, item(227, all) > 0, english, ".+"-> inform ("[Quest Solved] You are awarded a wooden spoon."), deleteItem(227,1), item(227, 1, 566), queststatus(514) = 2, "Thank you! Now I can get this stew started! Here, why don't you take my old one. It may yet still have some use left in it."
-queststatus(514) = 1, item(227, all) > 0, ".+" -> inform ("[Quest gelöst] Du erhältst das hölzerner Löffel."), deleteItem(227,1), item(227, 1, 566), queststatus(514) = 2, "Danke! Jetzt kann ich den Eintopf machen! Hier, nimm meinen alten Löffel. Er könnte noch von Nutzen sein."
+queststatus(514) = 1, item(227, all) > 0, ".+" -> inform ("[Quest gelöst] Du erhältst einen Kochlöffel."), deleteItem(227,1), item(227, 1, 566), queststatus(514) = 2, "Danke! Jetzt kann ich den Eintopf machen! Hier, nimm meinen alten Kochlöffel. Er könnte noch von Nutzen sein."
 
 -- Quest 2: Needs 25 Cabbages, reward 30 silver
 queststatus(514) = 2, english, "quest", "mission" -> inform ("[New Quest] A Good Deed for Oldra II"), queststatus(514) = 3, "It seems I may have misread my recipe and did not buy enough cabbages the other day. Would you be so kind as to pick up the remaining twenty five for me?"

--- a/npc/eleanor_fairbanks.npc
+++ b/npc/eleanor_fairbanks.npc
@@ -98,17 +98,17 @@ english, "Ciao", "Adieu", "Au revoir", "Farebba" -> "Farewell! May Oldra's bless
 
 -- Quest 1: New wooden spoon, for old spoon
 queststatus(514) = 0, english, "quest", "mission" -> inform ("[New Quest] A Good Deed for Oldra"), money + 2000, queststatus(514) = 1, "Oh! I do have something you could help me with. It seems my wooden spoon has seen better days. Could you go visit the market place in Runewick and get me a new one? Here, take these coins."
-queststatus(514) = 0, "quest", "mission" -> inform ("[Neue Quest] Ein Gute Tat für Oldra"), money + 2000, queststatus(514) = 1, "Oh! Ich habe etwas wobei du mir helfen kannst. Mein Holzlöffel hat schon bessere Tage gesehen. Kannst du den Marktplatz in Runewick besuchen und mir einen neuen bringen? Hier, nimm diese Münzen."
+queststatus(514) = 0, "quest", "mission" -> inform ("[Neue Quest] Ein Gute Tat für Oldra"), money + 2000, queststatus(514) = 1, "Oh! Ich habe etwas wobei du mir helfen kannst. Mein Kochlöffel hat schon bessere Tage gesehen. Kannst du den Marktplatz in Runewick besuchen und mir einen neuen bringen? Hier, nimm diese Münzen."
 queststatus(514) = 0, "task", "adventure", "order" -> inform ("[New Quest] A Good Deed for Oldra"), money + 2000, queststatus(514) = 1, "Oh! I do have something you could help me with. It seems my wooden spoon has seen better days. Could you go visit the market place in Runewick and get me a new one? Here, take these coins."
-queststatus(514) = 0, "Auftrag", "Aufgabe", "Abenteuer", "Befehl"-> inform ("[Neue Quest] Ein Gute Tat für Oldra"), money + 2000, queststatus(514) = 1, "Oh! Ich habe etwas wobei du mir helfen kannst. Mein Holzlöffel hat schon bessere Tage gesehen. Kannst du den Marktplatz in Runewick besuchen und mir einen neuen bringen? Hier, nimm diese Münzen."
+queststatus(514) = 0, "Auftrag", "Aufgabe", "Abenteuer", "Befehl"-> inform ("[Neue Quest] Ein Gute Tat für Oldra"), money + 2000, queststatus(514) = 1, "Oh! Ich habe etwas wobei du mir helfen kannst. Mein Kochlöffel hat schon bessere Tage gesehen. Kannst du den Marktplatz in Runewick besuchen und mir einen neuen bringen? Hier, nimm diese Münzen."
 
 --Not done
 queststatus(514) = 1, item(227, all) < 1, english, ".+" -> "Have you gotten me that spoon yet?"
-queststatus(514) = 1, item(227, all) < 1, ".+" -> "Hast du mir den Löffel mitgebracht?"
+queststatus(514) = 1, item(227, all) < 1, ".+" -> "Hast du mir den Kocklöffel mitgebracht?"
 
 --done
 queststatus(514) = 1, item(227, all) > 0, english, ".+"-> inform ("[Quest Solved] You are awarded a wooden spoon."), deleteItem(227,1), item(227, 1, 566), queststatus(514) = 2, "Thank you! Now I can get this stew started! Here, why don't you take my old one. It may yet still have some use left in it."
-queststatus(514) = 1, item(227, all) > 0, ".+" -> inform ("[Quest gelöst] Du erhältst das hölzerner Löffel."), deleteItem(227,1), item(227, 1, 566), queststatus(514) = 2, "Danke! Jetzt kann ich den Eintopf machen! Hier, nimm meinen alten Löffel. Er könnte noch von Nutzen sein."
+queststatus(514) = 1, item(227, all) > 0, ".+" -> inform ("[Quest gelöst] Du erhältst einen Kochlöffel."), deleteItem(227,1), item(227, 1, 566), queststatus(514) = 2, "Danke! Jetzt kann ich den Eintopf machen! Hier, nimm meinen alten Kochlöffel. Er könnte noch von Nutzen sein."
 
 -- Quest 2: Needs 25 Cabbages, reward 30 silver
 queststatus(514) = 2, english, "quest", "mission" -> inform ("[New Quest] A Good Deed for Oldra II"), queststatus(514) = 3, "It seems I may have misread my recipe and did not buy enough cabbages the other day. Would you be so kind as to pick up the remaining twenty five for me?"

--- a/npc/numila_irunnleh.npc
+++ b/npc/numila_irunnleh.npc
@@ -301,7 +301,7 @@ english, "Wulfgorda" -> "Wulfgorda is a hunter who knows almost every place in t
 "Coward last stand" -> "It is northeast from Yewdale on the way to Merryglade. The coward was none other than Sir Edward from Cadomyr. There is a rumour that he ran faster than an arrow of Malachin when he was attacked by Galmair supporters."
 "Feiglings letztes Gefecht" -> "Dieser Ort liegt nordöstlich von Eibenthal am Weg zur Fröhlichen Lichtung. Der angesprochene Feigling war Sir Edward von Cadomyr. Es heißt, er lief schneller als ein Pfeil von Malachin als er dort von Galmair Anhängern angegriffen wurde."
 "Outpost" -> "The outpost is northeast from Yewdale at a bridge. We used it in the past to protect ourselves."
-"Außenposten" -> "Dieser Außenposten liegt nordöstlich von Yewdale an einer Brücke. Wir verwendeten ihn in der Vergangenheit um uns zu schützen."
+"Außenposten" -> "Dieser Außenposten liegt nordöstlich von Eibenthal an einer Brücke. Wir verwendeten ihn in der Vergangenheit um uns zu schützen."
 "Anthil Brook" -> "Anthil Brook is north of Yewdale. You will find there some sign of our glorious victory during the Halfling-war against Galmair years ago."
 "Anthilbach" -> "Der Anthilbach liegt nördlich von Eibenthal. Du findest dort Hinweise zu unserem glorreichen Sieg im Halblingkrieg über Glamair vor einigen Jahren."
 "Bear cave" -> "The Bear cave is north of Anthill Brook. The cave was used by bears until warriors from Galmair killed them. Nowadays you can find some wolves and other animals there. A good place to practise some combat skills for inexperienced warriors."

--- a/npc/numila_irunnleh.npc
+++ b/npc/numila_irunnleh.npc
@@ -301,7 +301,7 @@ english, "Wulfgorda" -> "Wulfgorda is a hunter who knows almost every place in t
 "Coward last stand" -> "It is northeast from Yewdale on the way to Merryglade. The coward was none other than Sir Edward from Cadomyr. There is a rumour that he ran faster than an arrow of Malachin when he was attacked by Galmair supporters."
 "Feiglings letztes Gefecht" -> "Dieser Ort liegt nordöstlich von Eibenthal am Weg zur Fröhlichen Lichtung. Der angesprochene Feigling war Sir Edward von Cadomyr. Es heißt, er lief schneller als ein Pfeil von Malachin als er dort von Galmair Anhängern angegriffen wurde."
 "Outpost" -> "The outpost is northeast from Yewdale at a bridge. We used it in the past to protect ourselves."
-"Außenposten" -> "Dieser Außenposten liegt nordöstlich von Eibenthal an einer Brücke. Wir verwendeten ihn in der Vergangenheit um uns zu schützen."
+"Außenposten" -> "Dieser Außenposten liegt nordöstlich von Yewdale an einer Brücke. Wir verwendeten ihn in der Vergangenheit um uns zu schützen."
 "Anthil Brook" -> "Anthil Brook is north of Yewdale. You will find there some sign of our glorious victory during the Halfling-war against Galmair years ago."
 "Anthilbach" -> "Der Anthilbach liegt nördlich von Eibenthal. Du findest dort Hinweise zu unserem glorreichen Sieg im Halblingkrieg über Glamair vor einigen Jahren."
 "Bear cave" -> "The Bear cave is north of Anthill Brook. The cave was used by bears until warriors from Galmair killed them. Nowadays you can find some wolves and other animals there. A good place to practise some combat skills for inexperienced warriors."


### PR DESCRIPTION
Text Improvements
Fixed mixtured use of Yewdale/Eibenthal in german translation. 'Eibenthal' ist the right
Fixed correct name of item 227 in german texts: It is 'Kochlöffel. Not Holzlöffel or Löffel.