### PR TITLE
Makes it so torches can only be lit in hand

### DIFF
--- a/item/lights.lua
+++ b/item/lights.lua
@@ -70,7 +70,12 @@ local getLightData
 local setLightData
 
 function M.UseItem(User, SourceItem, ltstate)
-
+    if SourceItem.id == 391 and SourceItem:getType()~=4 then
+        common.InformNLS(User,
+            "Nimm die Lichtquelle in die Hand.",
+            "Take the light source into your hand.")
+        return
+    end
     if SourceItem:getType()==1 or SourceItem:getType()==2 then
         common.InformNLS(User,
             "Nimm die Lichtquelle in die Hand oder lege sie am Gürtel ab.",

--- a/item/lights.lua
+++ b/item/lights.lua
@@ -70,7 +70,7 @@ local getLightData
 local setLightData
 
 function M.UseItem(User, SourceItem, ltstate)
-    if SourceItem.id == 391 and SourceItem:getType()~=4 then
+    if SourceItem.id == Item.torch and SourceItem:getType()~=4 then
         common.InformNLS(User,
             "Nimm die Lichtquelle in die Hand.",
             "Take the light source into your hand.")


### PR DESCRIPTION
Upon request by Slightly, in case of user error during the tutorial quest to light a torch held in your hand.
This change prevents torches from being lit in your belt. Any other light item will function as before.