### PR TITLE
fighting: do not learn with broken weapon/parry item

### DIFF
--- a/server/standardfighting.lua
+++ b/server/standardfighting.lua
@@ -1570,7 +1570,7 @@ function LearnSuccess(Attacker, Defender, AP, Globals)
     -- Defender learns armour skill
     if Defender.DefenseSkillName then
         local armourfound, _ = world:getArmorStruct(Globals.HittedItem.id)
-        if armourfound then
+        if armourfound and not common.isBroken(Globals.HittedItem) then
             Defender.Char:learn(Defender.DefenseSkillName,(AP)/3,Attacker.skill + 20)
         end
     end

--- a/server/standardfighting.lua
+++ b/server/standardfighting.lua
@@ -1577,25 +1577,9 @@ function LearnSuccess(Attacker, Defender, AP, Globals)
 
     local parryWeapon, parryItem = GetParryWeaponAndItem(Defender)
 
-    -- Defender learns only with a valid parry weapon
-    if parryWeapon then
-        --Choose which weapon has the largest defence
-        if Defender.IsWeapon then
-            parryWeapon = Defender.Weapon
-        end
-
-        if Defender.SecIsWeapon then
-            if not parryWeapon then
-                parryWeapon = Defender.SecWeapon
-            elseif (parryWeapon.Defence < Defender.SecWeapon.Defence) or common.isBroken(parryWeapon) then
-                parryWeapon = Defender.SecWeapon
-            end
-        end
-
-        -- Defender learns parry skill
-        if parryWeapon and not common.isBroken(parryWeapon) then
-            Defender.Char:learn(Character.parry, AP/3, Attacker.skill + 20)
-        end
+    -- Defender learns only with a valid non-broken parry weapon
+    if parryWeapon ~= nil then
+        Defender.Char:learn(Character.parry, AP/3, Attacker.skill + 20)
     end
 end
 

--- a/server/standardfighting.lua
+++ b/server/standardfighting.lua
@@ -774,7 +774,7 @@ end
 -- @param Defender The character who is attacked
 local function GetParryWeaponAndItem(Defender)
     local parryWeapon
-    local parryItem -- For degradation
+    local parryItem = nil -- For degradation
 
     --Choose which weapon has the largest defence
     if Defender.IsWeapon then
@@ -792,7 +792,7 @@ local function GetParryWeaponAndItem(Defender)
         end
     end
 
-    if common.isBroken(parryItem) then
+    if parryItem == nil or common.isBroken(parryItem) then
         return nil, nil
     else
         return parryWeapon, parryItem


### PR DESCRIPTION
Fixes #242. If the attackers weapon is broken, he is not able to learn (I would be against treating this case as "wrestling", as its hard to wrestle with a broken weapon in the hand). Likewise, the defender cannot learn if he only has broken parry/armour items.

TBD: Testing on a local server:

* Equip broken weapon/shield/armours and go fight somewhere. The fighting skills should not improve.
