### PR TITLE
Added target validity checks for some nature spells

### DIFF
--- a/magic/nature/effects/seegwynt.lua
+++ b/magic/nature/effects/seegwynt.lua
@@ -72,6 +72,11 @@ local function clearSpace(user, objectLimit, objectId)
         local theField = world:getField(thePosition)
         local itemFound = false
 
+        if not theField then
+            table.remove(positionsToCheck, index)
+            return
+        end
+
         for i = 1, theField:countItems() do
             local checkItem = theField:getStackItem(theField:countItems() - i )
             if objectId == checkItem.id then
@@ -139,6 +144,10 @@ local function isSoil(location) -- A seedling needs suitable soil to be able to 
     local suitableSoilList = {3, 4, 8, 9, 10, 11, 12, 14, 16, 74, 75}
 
     local theField = world:getField(location)
+
+    if not theField then
+        return false
+    end
 
     local myFieldId = theField:tile()
 

--- a/magic/nature/effects/sergwynt.lua
+++ b/magic/nature/effects/sergwynt.lua
@@ -33,6 +33,10 @@ function M.effect(user, location, target)
 
     world:gfx(58, location)
     world:makeSound(13, location)
+    if not target or not isValidChar(target) then
+        return
+    end
+
     local amount = getAntidoteAmount(user, "Sergwynt")
     poison.applyAntidote(target, amount)
 end

--- a/magic/nature/poison.lua
+++ b/magic/nature/poison.lua
@@ -26,6 +26,10 @@ local poisonDuration = 10 -- 10 seconds
 
 function M.applyPoison(target, damage, antidote, user)
 
+    if not target or not isValidChar(target) then
+        return
+    end
+
     damage = math.floor(damage) -- ensure whole integer
 
     local foundEffect, myEffect = target.effects:find(poisonEffectId)


### PR DESCRIPTION
Evie reported the following script errors today:

```
Jun 4  14:55:12 Script (err): /usr/share/illarion/scripts/magic/nature/poison.lua:31: attempt to index local 'target' (a boolean value)

Jun 4 15:17:21 Script (err): /usr/share/illarion/scripts/magic/nature/effects/seegwynt.lua:75: attempt to index local 'theField' (a nil value)
```

This PR fixes these by adding validity and not-nil checks.