### PR TITLE
Fix divide by zero issue in alchemy.lua

### DIFF
--- a/alchemy/base/alchemy.lua
+++ b/alchemy/base/alchemy.lua
@@ -452,7 +452,7 @@ local function getBrewingDuration(user, id)
             if herb.id == id then
                 local commonHerb = world:getItemStatsFromId(herb.id)
                 local diff = alchemyLevel - commonHerb.Level
-                local max = 100 - commonHerb.Level
+                local max = math.max(1, 100 - commonHerb.Level)
                 local maxReduction = 15
                 local reductionPerLevel = maxReduction / max
                 local reduction = reductionPerLevel*diff


### PR DESCRIPTION
Addressing the bug reported here: https://illarion.org/community/forums/viewtopic.php?p=719399&sid=c0be5ce00f125c65b4b5c9949715c3b9#p719399

DESCRIPTION: Adjusted the "max" variable in to make sure the value can never go below 1, this was causing Mortars to break if the Common Herb level was 100, which was the case for Elf Caps.

SCRIPTS: https://github.com/Cancelpro/Illarion-Content/tree/MortarBreakBug

MAPS: https://github.com/Illarion-eV/Illarion-Map/tree/develop

Please test the following:

* Elf Caps no longer break mortars or break them earlier than expected.
* Ensure no other Alchemy ingredients' damage modifiers have been adjusted.
