### PR TITLE
Added alchemy bomb bottles to bottle list.

### DIFF
--- a/alchemy/base/alchemy.lua
+++ b/alchemy/base/alchemy.lua
@@ -271,6 +271,8 @@ function M.getListOfBottles()
 
     table.insert(retVal, Item.emptyPotion)
     table.insert(retVal, Item.emptySalveJar)
+    table.insert(retVal, Item.emptyAlchemyBomb)
+    table.insert(retVal, Item.unlitAlchemyBomb)
 
     for _, cauldronsAndBottle in pairs(cauldronsAndBottles) do
         table.insert(retVal, cauldronsAndBottle.bottle)


### PR DESCRIPTION
Addressing the second bug reported here: https://illarion.org/community/forums/viewtopic.php?p=719399&sid=c0be5ce00f125c65b4b5c9949715c3b9#p719399

DESCRIPTION: Added Alchemy Bomb bottles to the bottle list, this allows for them to be labelled with a quill, which is the only place the getListOfBottles method is called.

SCRIPTS: https://github.com/Cancelpro/Illarion-Content/tree/AlchemyBombLabel

MAPS: https://github.com/Illarion-eV/Illarion-Map/tree/develop

Please test the following:

    Ability to label and relabel alchemy bombs (empty and unlit)
    Ensure that empty Alchemy bombs keep their labels when they become "Unlit Alchemy Bombs"

