### PR TITLE
Add null-reference checks to see if food has any attributes

### DIFF
--- a/item/food.lua
+++ b/item/food.lua
@@ -480,6 +480,10 @@ local function buffsAdding(user, sourceItem)
         dishInfo = cookingRecipeCreation.getDishInfo(sourceItem)
         buffs = dishInfo.attributes
     else --It is an old or spawned in item
+        if common.IsNilOrEmpty(M.cookedFood[sourceItem.id].buffs) then
+            return
+        end
+
         local ingredients = M.cookedFood[sourceItem.id].ingredients
         dishInfo = cookingRecipeCreation.getDishInfo(nil, ingredients)
         buffs = {}


### PR DESCRIPTION
Addressing the second bug reported here: https://discord.com/channels/401855954272124940/1537438814920900740

DESCRIPTION: Added a null-reference check to the food buffs system, this issue was causing certain foods like doughs or other spawned in foods to error out and give infinite food, please let me know if this code follows illarion style guidelines or if my pull requests should be more gathered together.

SCRIPTS: https://github.com/Cancelpro/Illarion-Content/tree/BasicFixOfInfiniteFoodBug

MAPS: https://github.com/Illarion-eV/Illarion-Map/tree/develop

Please test the following:

Food with no attributes is edible and still removes eaten food from inventor
Ensure no adjustments to the food system to attribute giving have been made.
